### PR TITLE
Maximo CSRs Dataset

### DIFF
--- a/etl/queries.py
+++ b/etl/queries.py
@@ -67,3 +67,17 @@ WHERE w.SITEID = 'SBO'
   AND w.CHANGEDATE BETWEEN TO_DATE('{start}', 'MM/DD/YYYY')
     AND TO_DATE('{end}', 'MM/DD/YYYY')
 	"""
+
+service_requests = """
+SELECT DIM_TICKET_ID,
+       TICKETID,
+       STATUS,
+       STATUSDATE,
+       REPORTDATE,
+       ACTUALFINISH
+from MAXIMO_DM.FCT_TICKET
+WHERE CLASS = 'SR'
+  AND SITEID = 'SBO'
+  AND CHANGEDATE BETWEEN TO_DATE('{start}', 'MM/DD/YYYY')
+    AND TO_DATE('{end}', 'MM/DD/YYYY')
+"""


### PR DESCRIPTION
Part of https://github.com/cityofaustin/atd-data-tech/issues/21511

Adding a new query to this ETL's work_orders_to_socrata.py script. It searches the tickets table which is where CSRs come into the maximo system. This is then upserted to the maximo CSRs [dataset](https://datahub.austintexas.gov/Transportation-and-Mobility/Street-and-Bridge-Maximo-311-Service-Requests/2zms-x3x7/about_data). 

## Testing
1. Clone this repo and checkout `charlie-service-requests`
2. Fill out the `env_template`, [the airflow DAG for this repo](https://github.com/cityofaustin/atd-airflow/blob/2fe3c7672e97e4717f736e4a8690d27187f87923/dags/dts_maximo_reporting_work_orders.py#L25-L62) is useful for knowing exactly where the secrets are stored in our password manager.
3.  Either use the provided dockerfile or use a venv/conda environment with python 3.10 along with `pip install -r requirements.txt`
4. Make sure you are on VPN and test the queries with `python etl/work_orders_to_socrata.py`
5. Check that it completes!