### PR TITLE
Add alt reference ID to work orders dataset

### DIFF
--- a/etl/queries.py
+++ b/etl/queries.py
@@ -62,6 +62,7 @@ SELECT w.WONUM,
        w.HOLDREASON,
        cc.DESCRIPTION  AS CAUSE,
        rc.DESCRIPTION  AS REMEDY,
+       w.ALTREF,
        '{base_url}' || w.WONUM as WO_LINK
 FROM MAXIMO_DM.FCT_WORKORDER w
          LEFT OUTER JOIN (SELECT *


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/22878

Added `altref` column to receive the data to the dataset [here](https://datahub.austintexas.gov/Transportation-and-Mobility/Street-and-Bridge-Operations-Work-Orders/hjym-dxqr)

- [x] Reminder to myself to make sure that I rerun this query for the whole history of maximo work orders to populate this column