### PR TITLE
Work order status history dataset

### DIFF
--- a/etl/maximo_to_socrata.py
+++ b/etl/maximo_to_socrata.py
@@ -113,6 +113,7 @@ def cleanup_work_order_urls(data):
 
     return data
 
+
 def data_to_socrata(soda, data, dataset):
     """
     Replaces all the data in the socrata dataset with data in the dataframe.
@@ -143,7 +144,9 @@ def main(args):
     if "base_url" in query_params:
         # Building the direct url for work orders
         work_order_base_url = BASE_URL + maximo_url_search_params
-        query = query_template.format(base_url=work_order_base_url, start=start, end=end)
+        query = query_template.format(
+            base_url=work_order_base_url, start=start, end=end
+        )
     else:
         query = query_template.format(start=start, end=end)
 

--- a/etl/queries.py
+++ b/etl/queries.py
@@ -1,4 +1,4 @@
-query_template = """
+work_orders = """
 SELECT w.WONUM,
        w.DIM_ASSET_SK,
        w.DIM_WORK_LOC_SK,
@@ -101,4 +101,39 @@ WHERE CLASS = 'SR'
     AND TO_DATE('{end}', 'MM/DD/YYYY')
 """
 
-maximo_url_search_params = "event=loadapp&value=sbo_wotrk&additionalevent=useqbe&additionaleventvalue=wonum="
+work_order_status_history = """
+SELECT
+    WOSTATUSID,
+    WONUM,
+    STATUS,
+    CHANGEDATE,
+    CHANGEBY
+FROM MAXIMO_DM.LKP_WOSTATUS
+WHERE
+    SITEID='SBO' AND
+    CHANGEDATE BETWEEN TO_DATE('{start}', 'MM/DD/YYYY')
+    AND TO_DATE('{end}', 'MM/DD/YYYY')
+"""
+
+maximo_url_search_params = (
+    "event=loadapp&value=sbo_wotrk&additionalevent=useqbe&additionaleventvalue=wonum="
+)
+
+
+QUERIES = {
+    "work_orders": {
+        "template": work_orders,
+        "query_params": ["start", "end", "base_url"],
+        "dataset_resource_id": "hjym-dxqr",
+    },
+    "service_requests": {
+        "template": service_requests,
+        "query_params": ["start", "end"],
+        "dataset_resource_id": "2zms-x3x7",
+    },
+    "work_order_status_history": {
+        "template": work_order_status_history,
+        "query_params": ["start", "end"],
+        "dataset_resource_id": "dbbh-gygn",
+    },
+}

--- a/readme.md
+++ b/readme.md
@@ -2,21 +2,23 @@
 
 This repo stores scripts used by the Austin Transportation Public Works Department to access data stored in [Maximo](https://www.ibm.com/products/maximo) and for publishing the data elsewhere.
 
-## work_orders_to_socrata.py
+## maximo_to_socrata.py
 
 ![diagram of the dataflow going from the Maximo data warehouse oracle DB to the socrata city datahub](docs/dataflow.png)
 
-This script publishes work orders from the Maximo data warehouse oracle DB (full query in etl/queries.py) to the city datahub. This is done to make it easier for city staff to access the data for reporting needs in BI tools such as Power BI.
+This script publishes data from the Maximo data warehouse oracle DB to the city datahub. This is done to make it easier for city staff to access the data for reporting needs in BI tools such as Power BI.
 
-The two parameters this script takes is `--start` and `--end`, the start and end dates of the work orders to get (based on `CHANGEDATE`). The format of the date passed is quite flexible, so here is an example:
+The three parameters this script takes is `--start`, `--end`, and `--query`, the start and end dates of the work orders to get (based on the record's `CHANGEDATE`). The format of the date passed is quite flexible, so here is an example:
 
 Publishing work orders to the city datahub between August 31st, 2023 and September 9th, 2023:
 
-`$ python etl/work_orders_to_socrata.py --start 2023-08-31 --end 2023-09-09`
+`$ python etl/maximo_to_socrata.py --query work_orders --start 2023-08-31 --end 2023-09-09`
 
 Leaving out `--start` will default to 7 days ago. Leaving out `--end` will default to today. Publishing the work orders for the past week:
 
-`$ python etl/work_orders_to_socrata.py`
+`$ python etl/maximo_to_socrata.py --query work_orders`
+
+The `--query` determines which query `etl/queries.py` (defined as QUERIES) is run. All queries configured there must take `--start` and `--end` arguments.  
 
 # Network
 


### PR DESCRIPTION
Part of: https://github.com/cityofaustin/atd-data-tech/issues/22843

Adds a new [dataset](https://datahub.austintexas.gov/dataset/Street-and-Bridge-Operations-Work-Order-Status-His/dbbh-gygn/about_data) that stores the timeline of changes to work order statuses. 

I also refactored the code significantly as I expect we'll be pulling in more tables from Maximo in the future. This will require some changes to the existing airflow DAG and I will open a PR about that which will have to be deployed (merged) at the sametime as this PR. 